### PR TITLE
Set frontend with config

### DIFF
--- a/lib/streamlit/config.py
+++ b/lib/streamlit/config.py
@@ -870,6 +870,17 @@ _create_option(
     ),
 )
 
+_create_option(
+    "server.frontendPath",
+    description=(
+        """
+        When set, Streamlit will serve the frontend from the specified directory, rather
+        than from the internal Streamlit package. This is useful for development purposes
+        or for using a custom frontend.
+        """
+    ),
+)
+
 # Config Section: UI #
 
 _create_section("ui", "Configuration of UI elements displayed in the browser.")

--- a/lib/streamlit/file_util.py
+++ b/lib/streamlit/file_util.py
@@ -19,7 +19,7 @@ import io
 import os
 from pathlib import Path
 
-from streamlit import env_util, util
+from streamlit import config, env_util, util
 from streamlit.string_util import is_binary_string
 
 # Configuration and credentials are stored inside the ~/.streamlit folder
@@ -118,6 +118,8 @@ def streamlit_write(path, binary=False):
 
 def get_static_dir():
     """Get the folder where static HTML/JS/CSS files live."""
+    if config.get_option("server.frontendPath"):
+        return os.path.abspath(config.get_option("server.frontendPath"))
     dirname = os.path.dirname(os.path.normpath(__file__))
     return os.path.normpath(os.path.join(dirname, "static"))
 


### PR DESCRIPTION
<!--
⚠️ BEFORE CONTRIBUTING PLEASE READ OUR CONTRIBUTING GUIDELINES!
https://github.com/streamlit/streamlit/wiki/Contributing
-->

## Describe your changes

Allow user to specify a custom folder for serving frontend assets

Tested during hackathon with the following `.streamlit/config.toml`
```toml
[global]
developmentMode = false

[server]
frontendPath = "frontend/star-admin-pro-react/build/"
```

## GitHub Issue Link (if applicable)

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python)
- E2E Tests
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
