### PR TITLE
add ComponentMapper to allow plugging in custom compoment implementations

### DIFF
--- a/frontend/lib/src/ComponentMapper.tsx
+++ b/frontend/lib/src/ComponentMapper.tsx
@@ -1,0 +1,128 @@
+/**
+ * Copyright (c) Streamlit Inc. (2018-2022) Snowflake Inc. (2022)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+type ElementType =
+  | "alert"
+  | "arrowDataFrame"
+  | "arrowTable"
+  | "arrowVegaLiteChart"
+  | "audio"
+  | "balloons"
+  | "bokehChart"
+  | "button"
+  | "downloadButton"
+  | "cameraInput"
+  | "chatInput"
+  | "checkbox"
+  | "colorPicker"
+  | "componentInstance"
+  | "dataFrame"
+  | "table"
+  | "dateInput"
+  | "deckGlJsonChart"
+  | "docString"
+  | "empty"
+  | "exception"
+  | "favicon"
+  | "fileUploader"
+  | "graphvizChart"
+  | "iframe"
+  | "imgs"
+  | "json"
+  | "linkButton"
+  | "markdown"
+  | "metric"
+  | "multiselect"
+  | "numberInput"
+  | "plotlyChart"
+  | "progress"
+  | "radio"
+  | "selectbox"
+  | "skeleton"
+  | "slider"
+  | "snow"
+  | "spinner"
+  | "text"
+  | "textArea"
+  | "textInput"
+  | "timeInput"
+  | "toast"
+  | "vegaLiteChart"
+  | "video"
+  | "heading"
+  | "code"
+
+type ComponentMapType = {
+  [key in ElementType]: (props: any) => React.ReactElement
+}
+
+type MappingNotYetDefined = (props: any) => any
+
+type ExplicitComponentMap = {
+  juice: (props: string) => string
+  alert: (props: string) => string
+  arrowDataFrame: MappingNotYetDefined
+  arrowTable: MappingNotYetDefined
+  arrowVegaLiteChart: MappingNotYetDefined
+  audio: MappingNotYetDefined
+  balloons: MappingNotYetDefined
+  bokehChart: MappingNotYetDefined
+  button: MappingNotYetDefined
+  downloadButton: MappingNotYetDefined
+  cameraInput: MappingNotYetDefined
+  chatInput: MappingNotYetDefined
+  checkbox: MappingNotYetDefined
+  colorPicker: MappingNotYetDefined
+  componentInstance: MappingNotYetDefined
+  dataFrame: MappingNotYetDefined
+  table: MappingNotYetDefined
+  dateInput: MappingNotYetDefined
+  deckGlJsonChart: MappingNotYetDefined
+  docString: MappingNotYetDefined
+  empty: MappingNotYetDefined
+  exception: MappingNotYetDefined
+  favicon: MappingNotYetDefined
+  fileUploader: MappingNotYetDefined
+  graphvizChart: MappingNotYetDefined
+  iframe: MappingNotYetDefined
+  imgs: MappingNotYetDefined
+  json: MappingNotYetDefined
+  linkButton: MappingNotYetDefined
+  markdown: MappingNotYetDefined
+  metric: MappingNotYetDefined
+  multiselect: MappingNotYetDefined
+  numberInput: MappingNotYetDefined
+  plotlyChart: MappingNotYetDefined
+  progress: MappingNotYetDefined
+  radio: MappingNotYetDefined
+  selectbox: MappingNotYetDefined
+  skeleton: MappingNotYetDefined
+  slider: MappingNotYetDefined
+  snow: MappingNotYetDefined
+  spinner: MappingNotYetDefined
+  text: MappingNotYetDefined
+  textArea: MappingNotYetDefined
+  textInput: MappingNotYetDefined
+  timeInput: MappingNotYetDefined
+  toast: MappingNotYetDefined
+  vegaLiteChart: MappingNotYetDefined
+  video: MappingNotYetDefined
+  heading: (props: { value: string }) => React.ReactElement
+  code: MappingNotYetDefined
+}
+
+// constrain to element types
+export type ComponentMapper = ExplicitComponentMap | ComponentMapType

--- a/frontend/lib/src/components/StreamlitView/StreamlitView.tsx
+++ b/frontend/lib/src/components/StreamlitView/StreamlitView.tsx
@@ -30,6 +30,7 @@ import { StreamlitEndpoints } from "@streamlit/lib/src/StreamlitEndpoints"
 import { BaseUriParts, buildHttpUri } from "@streamlit/lib/src/util/UriUtil"
 
 import { useStreamlitElementTree } from "../StreamlitApp/stores/StreamlitElementTreeContext"
+import { ComponentMapper } from "../../ComponentMapper"
 
 const COMPONENT_ENDPOINT_BASE = "/component"
 const MEDIA_ENDPOINT = "/media"
@@ -76,10 +77,12 @@ class DummyEndpoints implements StreamlitEndpoints {
 
 export interface StreamlitViewProps {
   namespace: string
+  componentMapper?: ComponentMapper
 }
 
 export function StreamlitView({
   namespace,
+  componentMapper,
 }: StreamlitViewProps): ReactElement {
   const { connectionState, workingEndpoint } = useStreamlitConnection()
   const { widgetManager, formsData } = useWidgetStateManager()
@@ -127,6 +130,7 @@ export function StreamlitView({
       uploadClient={uploadClient}
       componentRegistry={componentRegistry}
       formsData={formsData}
+      componentMapper={componentMapper}
     />
   )
 }

--- a/frontend/lib/src/components/core/Block/ElementNodeRenderer.tsx
+++ b/frontend/lib/src/components/core/Block/ElementNodeRenderer.tsx
@@ -243,6 +243,20 @@ const RawElementNodeRenderer = (
   // since leaf elements are always direct children of a VerticalBlock, which always calculates
   const width = props.width ?? 0
 
+  if (
+    node.element.type &&
+    props.componentMapper &&
+    props.componentMapper[node.element.type]
+  ) {
+    const componentFunc = props.componentMapper[node.element.type]
+    switch (node.element.type) {
+      case "heading":
+        return componentFunc({
+          value: node.element.heading?.body,
+        })
+    }
+  }
+
   switch (node.element.type) {
     case "alert": {
       const alertProto = node.element.alert as AlertProto

--- a/frontend/lib/src/components/core/Block/utils.ts
+++ b/frontend/lib/src/components/core/Block/utils.ts
@@ -25,6 +25,7 @@ import { ComponentRegistry } from "@streamlit/lib/src/components/widgets/CustomC
 import { SessionInfo } from "@streamlit/lib/src/SessionInfo"
 import { StreamlitEndpoints } from "@streamlit/lib/src/StreamlitEndpoints"
 import { EmotionTheme, getDividerColors } from "@streamlit/lib/src/theme"
+import type { ComponentMapper } from "src/ComponentMapper"
 
 export function shouldComponentBeEnabled(
   elementType: string,
@@ -149,4 +150,6 @@ export interface BaseBlockProps {
    * from that callback.
    */
   formsData: FormsData
+
+  componentMapper?: ComponentMapper
 }

--- a/frontend/star-admin-pro-react/src/app/dashboard/Dashboard.js
+++ b/frontend/star-admin-pro-react/src/app/dashboard/Dashboard.js
@@ -1241,7 +1241,17 @@ export class Dashboard extends Component {
           <div className="col-md-8 grid-margin stretch-card">
             <div className="card">
               <div className="card-body">
-                <StreamlitView />
+                <StreamlitView
+                  componentMapper={{
+                    heading: ({ value }) => {
+                      return (
+                        <h3 style={{ fontSize: "100px", fontStyle: "italic" }}>
+                          {value}
+                        </h3>
+                      )
+                    },
+                  }}
+                />
               </div>
             </div>
           </div>


### PR DESCRIPTION
<!--
⚠️ BEFORE CONTRIBUTING PLEASE READ OUR CONTRIBUTING GUIDELINES!
https://github.com/streamlit/streamlit/wiki/Contributing
-->

## Describe your changes

Add a "ComponentMapper" which allows overriding the default component implementations with custom ones. This allows plugging in custom component implementations (e.g. core-ui, chakra, other component libraries, or custom rolled). There's a mapping from the protobuf element type e.g. `heading` to what component should be rendered. This mapping also transforms props from the protobuf. Those are not yet defined (I just implemented `value` for `heading` as an example how to do this).

<img width="1567" alt="Screenshot 2023-12-12 at 1 18 41 PM" src="https://github.com/kmcgrady/streamlit/assets/120425922/215efdb3-9ed6-4f94-a7ae-dbb18c95db1e">


## GitHub Issue Link (if applicable)

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python)
- E2E Tests
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all contributions to this project are made under the Apache 2.0 license.
